### PR TITLE
refactor: simplify catppuccin_theme function

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -61,77 +61,74 @@ local frappe_palette = {
 }
 
 local macchiato_palette = {
-    rosewater = "#f4dbd6",
-    flamingo = "#f0c6c6",
-    pink = "#f5bde6",
-    mauve = "#c6a0f6",
-    red = "#ed8796",
-    maroon = "#ee99a0",
-    peach = "#f5a97f",
-    yellow = "#eed49f",
-    green = "#a6da95",
-    teal = "#8bd5ca",
-    sky = "#91d7e3",
-    sapphire = "#7dc4e4",
-    blue = "#8aadf4",
-    lavender = "#b7bdf8",
-    text = "#cad3f5",
-    subtext1 = "#b8c0e0",
-    subtext0 = "#a5adcb",
-    overlay2 = "#939ab7",
-    overlay1 = "#8087a2",
-    overlay0 = "#6e738d",
-    surface2 = "#5b6078",
-    surface1 = "#494d64",
-    surface0 = "#363a4f",
-    base = "#24273a",
-    mantle = "#1e2030",
-    crust = "#181926",
+  rosewater = "#f4dbd6",
+  flamingo = "#f0c6c6",
+  pink = "#f5bde6",
+  mauve = "#c6a0f6",
+  red = "#ed8796",
+  maroon = "#ee99a0",
+  peach = "#f5a97f",
+  yellow = "#eed49f",
+  green = "#a6da95",
+  teal = "#8bd5ca",
+  sky = "#91d7e3",
+  sapphire = "#7dc4e4",
+  blue = "#8aadf4",
+  lavender = "#b7bdf8",
+  text = "#cad3f5",
+  subtext1 = "#b8c0e0",
+  subtext0 = "#a5adcb",
+  overlay2 = "#939ab7",
+  overlay1 = "#8087a2",
+  overlay0 = "#6e738d",
+  surface2 = "#5b6078",
+  surface1 = "#494d64",
+  surface0 = "#363a4f",
+  base = "#24273a",
+  mantle = "#1e2030",
+  crust = "#181926",
 }
 
 local mocha_palette = {
-    rosewater = "#f5e0dc",
-    flamingo = "#f2cdcd",
-    pink = "#f5c2e7",
-    mauve = "#cba6f7",
-    red = "#f38ba8",
-    maroon = "#eba0ac",
-    peach = "#fab387",
-    yellow = "#f9e2af",
-    green = "#a6e3a1",
-    teal = "#94e2d5",
-    sky = "#89dceb",
-    sapphire = "#74c7ec",
-    blue = "#89b4fa",
-    lavender = "#b4befe",
-    text = "#cdd6f4",
-    subtext1 = "#bac2de",
-    subtext0 = "#a6adc8",
-    overlay2 = "#9399b2",
-    overlay1 = "#7f849c",
-    overlay0 = "#6c7086",
-    surface2 = "#585b70",
-    surface1 = "#45475a",
-    surface0 = "#313244",
-    base = "#1e1e2e",
-    mantle = "#181825",
-    crust = "#11111b",
+  rosewater = "#f5e0dc",
+  flamingo = "#f2cdcd",
+  pink = "#f5c2e7",
+  mauve = "#cba6f7",
+  red = "#f38ba8",
+  maroon = "#eba0ac",
+  peach = "#fab387",
+  yellow = "#f9e2af",
+  green = "#a6e3a1",
+  teal = "#94e2d5",
+  sky = "#89dceb",
+  sapphire = "#74c7ec",
+  blue = "#89b4fa",
+  lavender = "#b4befe",
+  text = "#cdd6f4",
+  subtext1 = "#bac2de",
+  subtext0 = "#a6adc8",
+  overlay2 = "#9399b2",
+  overlay1 = "#7f849c",
+  overlay0 = "#6c7086",
+  surface2 = "#585b70",
+  surface1 = "#45475a",
+  surface0 = "#313244",
+  base = "#1e1e2e",
+  mantle = "#181825",
+  crust = "#11111b",
 }
 
 --- Gets the Catppuccin theme.
 --- @param flavor string Flavor of the theme: "latte", "frappe", "macchiato" or "mocha".
 --- @return table theme Used in Yatline.
 local function catppuccin_theme(flavor)
-  local catppuccin_palette
-  if flavor == "latte" then
-    catppuccin_palette = latte_palette
-  elseif flavor == "frappe" then
-    catppuccin_palette = frappe_palette
-  elseif flavor == "macchiato" then
-    catppuccin_palette = macchiato_palette
-  else
-    catppuccin_palette = mocha_palette
-  end
+  local palettes = {
+    latte = latte_palette,
+    frappe = frappe_palette,
+    macchiato = macchiato_palette,
+  }
+
+  local catppuccin_palette = palettes[flavor] or mocha_palette
 
   return {
     -- yatline
@@ -149,8 +146,8 @@ local function catppuccin_theme(flavor)
       bg_mode = {
         normal = catppuccin_palette.blue,
         select = catppuccin_palette.mauve,
-        un_set = catppuccin_palette.red
-      }
+        un_set = catppuccin_palette.red,
+      },
     },
     style_b = { bg = catppuccin_palette.surface0, fg = catppuccin_palette.text },
     style_c = { bg = catppuccin_palette.mantle, fg = catppuccin_palette.text },
@@ -185,8 +182,10 @@ local function catppuccin_theme(flavor)
   }
 end
 
-return { setup = function(_, args)
-  args = args or "mocha"
+return {
+  setup = function(_, args)
+    args = args or "mocha"
 
-  return catppuccin_theme(args)
-end }
+    return catppuccin_theme(args)
+  end,
+}


### PR DESCRIPTION
- Simplify catppuccin_theme function by using a palette table
- Format code with stylua